### PR TITLE
Update definition of the ⚡ for opensource

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ properties are evaluated:
 
 
 
-| Software               | Open-Source                           | Published                                           | Documentation                            | Type of ML | Control over ML     | 
-|:----------------------:|:-------------------------------------:|:---------------------------------------------------:|:----------------------------------------:|:----------:|:-------------------:|
-| [ASReview](#asreview)  |[:link:](https://github.com/asreview/) |[:link:](https://doi.org/10.1038/s42256-020-00287-7) |[:link:](https://asreview.readthedocs.io/)|   **A**    |:white_check_mark:`+`|
+| Software               | Open-Source                                             | Published                                           | Documentation                            | Type of ML | Control over ML     | 
+|:----------------------:|:-------------------------------------------------------:|:---------------------------------------------------:|:----------------------------------------:|:----------:|:-------------------:|
+| [ASReview](#asreview)  |:white_check_mark:[:link:](https://github.com/asreview/) |[:link:](https://doi.org/10.1038/s42256-020-00287-7) |[:link:](https://asreview.readthedocs.io/)|   **A**    |:white_check_mark:`+`|
 
 :white_check_mark: Yes/Implemented;
 :x: No/Not implemented;


### PR DESCRIPTION
This PR redefines the use of ⚡ in the category open-source from "with some effort" to "Some open-source repositories are publically available, but not the core engine"