### PR TITLE
Changes to training data table

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,16 +111,16 @@ The tables below provide an overview of the machine learning properties.
 
 
 
-|            Software             |  Tr.Data by user   | Partly labeled Tr.data | Minimum Tr.data |
-|:-------------------------------:|:------------------:|:----------------------:|:---------------:|
-|      [ASReview](#asreview)      | :white_check_mark: |   :white_check_mark:   |     ≥1R+≥1I     |
-|     [Abstrackr](#abstrackr)     |        :x:         |          :x:           |       :x:       |
-|       [Colandr](#colandr)       | :white_check_mark: |   :white_check_mark:   |       10        |
-| [EPPI-Reviewer](#eppi-reviewer) | :white_check_mark: |   :white_check_mark:   |       ≥5R       |
-|      [FASTREAD](#fastread)      |                    |                        |                 |
-|        [Rayyan](#rayyan)        | :white_check_mark: |   :white_check_mark:   |  ≥50 with ≥5R   |
-|  [RobotAnalyst](#robotanalyst)  |                    |                        |                 |
-|  [SWIFT-Review](#swift-review)  |                    |                        |                 |
+|            Software             |  Tr.Data by user   | Minimum Tr.data |
+|:-------------------------------:|:------------------:|:---------------:|
+|      [ASReview](#asreview)      | :white_check_mark: |     ≥1R+≥1I     |
+|     [Abstrackr](#abstrackr)     |        :x:         |       :x:       |
+|       [Colandr](#colandr)       | :white_check_mark: |       10        |
+| [EPPI-Reviewer](#eppi-reviewer) | :white_check_mark: |       ≥5R       |
+|      [FASTREAD](#fastread)      |                    |                 |
+|        [Rayyan](#rayyan)        | :white_check_mark: |  ≥50 with ≥5R   |
+|  [RobotAnalyst](#robotanalyst)  |                    |                 |
+|  [SWIFT-Review](#swift-review)  |                    |                 |
 
 :white_check_mark: Yes/Implemented;
 :x: No/Not implemented;

--- a/README.md
+++ b/README.md
@@ -113,12 +113,12 @@ The tables below provide an overview of the machine learning properties.
 
 |            Software             |  Tr.Data by user   | Partly labeled Tr.data | Minimum Tr.data |
 |:-------------------------------:|:------------------:|:----------------------:|:---------------:|
-|      [ASReview](#asreview)      | :white_check_mark: |   :white_check_mark:   |      1R+1I      |
+|      [ASReview](#asreview)      | :white_check_mark: |   :white_check_mark:   |     ≥1R+≥1I     |
 |     [Abstrackr](#abstrackr)     |        :x:         |          :x:           |       :x:       |
-|       [Colandr](#colandr)       | :white_check_mark: |   :white_check_mark:   |       10R       |
-| [EPPI-Reviewer](#eppi-reviewer) | :white_check_mark: |   :white_check_mark:   |       5R        |
+|       [Colandr](#colandr)       | :white_check_mark: |   :white_check_mark:   |       10        |
+| [EPPI-Reviewer](#eppi-reviewer) | :white_check_mark: |   :white_check_mark:   |       ≥5R       |
 |      [FASTREAD](#fastread)      |                    |                        |                 |
-|        [Rayyan](#rayyan)        | :white_check_mark: |          :x:           |  ≥50 with ≥5R   |
+|        [Rayyan](#rayyan)        | :white_check_mark: |   :white_check_mark:   |  ≥50 with ≥5R   |
 |  [RobotAnalyst](#robotanalyst)  |                    |                        |                 |
 |  [SWIFT-Review](#swift-review)  |                    |                        |                 |
 


### PR DESCRIPTION
- Distinguish between fixed training data and custom (but with min. requirement), by using '≥'
- Fixed mistake: Colandr starts training after 10 screenings, regardless of labeling decision
- Remove partly labeled tr.data column because it essentially contains the same info as the "Partly labeled" column in the "Data" table